### PR TITLE
Update gems to latest heroku-18 supports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source 'https://rubygems.org'
 
-ruby "3.2.2"
+ruby "3.2.2" # ruby 3.2.3 does NOT run on heroku-18!
 
 gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git', branch: 'morph_defaults'
-gem 'mechanize', "~> 2.8.5"
-gem "nokogiri", "~> 1.15.0"
-gem "sqlite3", "~> 1.6.3"
+gem 'mechanize', "~> 2.14"
+gem "nokogiri", "~> 1.17.2" # nokogiri 1.18 does NOT run on heroku-18!
+gem "sqlite3", "~> 2.2.0" # sqlite3 2.3.0 does NOT run on heroku-18!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,13 +20,15 @@ GEM
     httpclient (2.9.0)
       mutex_m
     logger (1.7.0)
-    mechanize (2.8.5)
+    mechanize (2.14.0)
       addressable (~> 2.8)
+      base64
       domain_name (~> 0.5, >= 0.5.20190701)
       http-cookie (~> 1.0, >= 1.0.3)
-      mime-types (~> 3.0)
+      mime-types (~> 3.3)
       net-http-digest_auth (~> 1.4, >= 1.4.1)
       net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
       nokogiri (~> 1.11, >= 1.11.2)
       rubyntlm (~> 0.6, >= 0.6.3)
       webrick (~> 1.7)
@@ -39,28 +41,29 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
-    nokogiri (1.15.7-aarch64-linux)
+    nkf (0.3.0)
+    nokogiri (1.17.2-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.7-arm-linux)
+    nokogiri (1.17.2-arm-linux)
       racc (~> 1.4)
-    nokogiri (1.15.7-arm64-darwin)
+    nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.7-x86-linux)
+    nokogiri (1.17.2-x86-linux)
       racc (~> 1.4)
-    nokogiri (1.15.7-x86_64-darwin)
+    nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.7-x86_64-linux)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     public_suffix (6.0.2)
     racc (1.8.1)
     rubyntlm (0.6.5)
       base64
-    sqlite3 (1.6.9-aarch64-linux)
-    sqlite3 (1.6.9-arm-linux)
-    sqlite3 (1.6.9-arm64-darwin)
-    sqlite3 (1.6.9-x86-linux)
-    sqlite3 (1.6.9-x86_64-darwin)
-    sqlite3 (1.6.9-x86_64-linux)
+    sqlite3 (2.2.0-aarch64-linux-gnu)
+    sqlite3 (2.2.0-arm-linux-gnu)
+    sqlite3 (2.2.0-arm64-darwin)
+    sqlite3 (2.2.0-x86-linux-gnu)
+    sqlite3 (2.2.0-x86_64-darwin)
+    sqlite3 (2.2.0-x86_64-linux-gnu)
     sqlite_magic (0.0.6)
       sqlite3
     webrick (1.9.1)
@@ -75,10 +78,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  mechanize (~> 2.8.5)
-  nokogiri (~> 1.15.0)
+  mechanize (~> 2.14)
+  nokogiri (~> 1.17.2)
   scraperwiki!
-  sqlite3 (~> 1.6.3)
+  sqlite3 (~> 2.2.0)
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,3 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+Bundler.require
+
 require 'scraperwiki'
 require 'mechanize'
 


### PR DESCRIPTION
## Description

Update gems to the latest versions supported by heroku-18 (morph.io's platform): mechanize ~> 2.14, nokogiri ~> 1.17.2, sqlite3 ~> 2.2.0. Add standalone header to scraper.rb (`bundler/setup` + `Bundler.require`) so it runs directly, and make it executable. Regenerate Gemfile.lock for ruby 3.2.2 with the x86_64-linux platform. (This repo has no dev/test gems, so no `group :development` was needed.)

## Motivation and Context

heroku-18 caps the gem versions morph.io can run (ruby 3.2.3, nokogiri 1.18 and sqlite3 2.3.0 all fail there). This applies the same pattern as the merged PRs planningalerts-scrapers/bawbaw#6, planningalerts-scrapers/banyule#10 and planningalerts-scrapers/multiple_technology_one#35, and replaces pending dependabot PRs.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

bundle install under ruby 3.2.2 via mise; `bundle lock --add-platform x86_64-linux`; local smoke run: scraper runs cleanly (exit 0) but the council site returns HTTP 202 with a 0-byte body to this machine (confirmed with curl, so it is bot-blocking, not a gem issue) — bundle verified only; site unreachable locally.

- [ ] Ran automated tests on my own system (no specs in this repo)
- [ ] Confirmed it passed the GitHub actions tests (no workflows in this repo)

## Screenshots (if appropriate):

N/A

## Types of Changes

Dependency update — no functional change to scraping behaviour.
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
Note: a verification run on morph.io under a fork is advisable before merging.

Assisted-by: OpenCode/anthropic.claude-fable-5

